### PR TITLE
Removed spark from PDM

### DIFF
--- a/ci/jobs/common-model-inputs/ucfs-mastered-data-dev.yml
+++ b/ci/jobs/common-model-inputs/ucfs-mastered-data-dev.yml
@@ -8,7 +8,7 @@ jobs:
           params:
             RESOURCE_FILES: "initialDeliveryUnitAddresses.json"
             RESOURCE_ROOT: organisation/src/main/resources/
-            S3_ROOT: common-model-inputs/data/address/
+            S3_ROOT: common-model-inputs/unclean/data/address/
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
             S3_BUCKET: ((dataworks.bucket-list.development.published))
           inputs:
@@ -18,7 +18,7 @@ jobs:
           params:
             RESOURCE_FILES: "initialOrganisation*.json"
             RESOURCE_ROOT: organisation/src/main/resources/
-            S3_ROOT: common-model-inputs/site/
+            S3_ROOT: common-model-inputs/unclean/site/
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
             S3_BUCKET: ((dataworks.bucket-list.development.published))
           inputs:

--- a/ci/jobs/common-model-inputs/ucfs-mastered-data-integration.yml
+++ b/ci/jobs/common-model-inputs/ucfs-mastered-data-integration.yml
@@ -8,7 +8,7 @@ jobs:
           params:
             RESOURCE_FILES: "initialDeliveryUnitAddresses.json"
             RESOURCE_ROOT: organisation/src/main/resources/
-            S3_ROOT: common-model-inputs/data/address/
+            S3_ROOT: common-model-inputs/unclean/data/address/
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.integration)):role/ci
             S3_BUCKET: ((dataworks.bucket-list.integration.published))
           inputs:
@@ -18,7 +18,7 @@ jobs:
           params:
             RESOURCE_FILES: "initialOrganisation*.json"
             RESOURCE_ROOT: organisation/src/main/resources/
-            S3_ROOT: common-model-inputs/site/
+            S3_ROOT: common-model-inputs/unclean/site/
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.integration)):role/ci
             S3_BUCKET: ((dataworks.bucket-list.integration.published))
           inputs:

--- a/ci/jobs/common-model-inputs/ucfs-mastered-data-preprod.yml
+++ b/ci/jobs/common-model-inputs/ucfs-mastered-data-preprod.yml
@@ -8,7 +8,7 @@ jobs:
           params:
             RESOURCE_FILES: "initialDeliveryUnitAddresses.json"
             RESOURCE_ROOT: organisation/src/main/resources/
-            S3_ROOT: common-model-inputs/data/address/
+            S3_ROOT: common-model-inputs/unclean/data/address/
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.preprod)):role/ci
             S3_BUCKET: ((dataworks.bucket-list.preprod.published))
           inputs:
@@ -18,7 +18,7 @@ jobs:
           params:
             RESOURCE_FILES: "initialOrganisation*.json"
             RESOURCE_ROOT: organisation/src/main/resources/
-            S3_ROOT: common-model-inputs/site/
+            S3_ROOT: common-model-inputs/unclean/site/
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.preprod)):role/ci
             S3_BUCKET: ((dataworks.bucket-list.preprod.published))
           inputs:

--- a/ci/jobs/common-model-inputs/ucfs-mastered-data-production.yml
+++ b/ci/jobs/common-model-inputs/ucfs-mastered-data-production.yml
@@ -8,7 +8,7 @@ jobs:
           params:
             RESOURCE_FILES: "initialDeliveryUnitAddresses.json"
             RESOURCE_ROOT: organisation/src/main/resources/
-            S3_ROOT: common-model-inputs/data/address/
+            S3_ROOT: common-model-inputs/unclean/data/address/
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.production)):role/ci
             S3_BUCKET: ((dataworks.bucket-list.production.published))
           inputs:
@@ -18,7 +18,7 @@ jobs:
           params:
             RESOURCE_FILES: "initialOrganisation*.json"
             RESOURCE_ROOT: organisation/src/main/resources/
-            S3_ROOT: common-model-inputs/site/
+            S3_ROOT: common-model-inputs/unclean/site/
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.production)):role/ci
             S3_BUCKET: ((dataworks.bucket-list.production.published))
           inputs:

--- a/ci/jobs/common-model-inputs/ucfs-mastered-data-qa.yml
+++ b/ci/jobs/common-model-inputs/ucfs-mastered-data-qa.yml
@@ -8,7 +8,7 @@ jobs:
           params:
             RESOURCE_FILES: "initialDeliveryUnitAddresses.json"
             RESOURCE_ROOT: organisation/src/main/resources/
-            S3_ROOT: common-model-inputs/data/address/
+            S3_ROOT: common-model-inputs/unclean/data/address/
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.qa)):role/ci
             S3_BUCKET: ((dataworks.bucket-list.qa.published))
           inputs:
@@ -18,7 +18,7 @@ jobs:
           params:
             RESOURCE_FILES: "initialOrganisation*.json"
             RESOURCE_ROOT: organisation/src/main/resources/
-            S3_ROOT: common-model-inputs/site/
+            S3_ROOT: common-model-inputs/unclean/site/
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.qa)):role/ci
             S3_BUCKET: ((dataworks.bucket-list.qa.published))
           inputs:

--- a/cluster_config/cluster.yaml.tpl
+++ b/cluster_config/cluster.yaml.tpl
@@ -1,6 +1,5 @@
 ---
 Applications:
-- Name: "Spark"
 - Name: "Hive"
 - Name: "Ganglia"
 CustomAmiId: "${ami_id}"

--- a/cluster_config/configurations.yaml.tpl
+++ b/cluster_config/configurations.yaml.tpl
@@ -4,25 +4,6 @@ Configurations:
   Properties:
     "yarn.log-aggregation-enable": "true"
     "yarn.nodemanager.remote-app-log-dir": "s3://${s3_log_bucket}/${s3_log_prefix}/yarn"
-- Classification: "spark"
-  Properties:
-    "maximizeResourceAllocation": "false"
-- Classification: "spark-defaults"
-  Properties:
-    "spark.yarn.jars": "/usr/lib/spark/jars/*,/usr/lib/hive/lib/metrics-core-2.2.0.jar,/usr/lib/hive/lib/htrace-core-3.1.0-incubating.jar"
-    "spark.sql.catalogImplementation": "hive"
-    "spark.yarn.dist.files": "/etc/spark/conf/hive-site.xml,/etc/pki/tls/private/private_key.key,/etc/pki/tls/certs/private_key.crt,/etc/pki/ca-trust/source/anchors/pdm_ca.pem"
-    "spark.executor.extraClassPath": "/usr/lib/hadoop-lzo/lib/*:/usr/lib/hadoop/hadoop-aws.jar:/usr/share/aws/aws-java-sdk/*:/usr/share/aws/emr/emrfs/conf:/usr/share/aws/emr/emrfs/lib/*:/usr/share/aws/emr/emrfs/auxlib/*:/usr/share/aws/emr/goodies/lib/emr-spark-goodies.jar:/usr/share/aws/emr/security/conf:/usr/share/aws/emr/security/lib/*:/usr/share/aws/hmclient/lib/aws-glue-datacatalog-spark-client.jar:/usr/share/java/Hive-JSON-Serde/hive-openx-serde.jar:/usr/share/aws/sagemaker-spark-sdk/lib/sagemaker-spark-sdk.jar:/usr/share/aws/emr/s3select/lib/emr-s3-select-spark-connector.jar:/usr/lib/hive/lib/metrics-core-2.2.0.jar:/usr/lib/hive/lib/htrace-core-3.1.0-incubating.jar"
-    "spark.driver.extraClassPath": "/usr/lib/hadoop-lzo/lib/*:/usr/lib/hadoop/hadoop-aws.jar:/usr/share/aws/aws-java-sdk/*:/usr/share/aws/emr/emrfs/conf:/usr/share/aws/emr/emrfs/lib/*:/usr/share/aws/emr/emrfs/auxlib/*:/usr/share/aws/emr/goodies/lib/emr-spark-goodies.jar:/usr/share/aws/emr/security/conf:/usr/share/aws/emr/security/lib/*:/usr/share/aws/hmclient/lib/aws-glue-datacatalog-spark-client.jar:/usr/share/java/Hive-JSON-Serde/hive-openx-serde.jar:/usr/share/aws/sagemaker-spark-sdk/lib/sagemaker-spark-sdk.jar:/usr/share/aws/emr/s3select/lib/emr-s3-select-spark-connector.jar:/usr/lib/hive/lib/metrics-core-2.2.0.jar:/usr/lib/hive/lib/htrace-core-3.1.0-incubating.jar"
-    "spark.executor.cores": "1"
-    "spark.executor.extraJavaOptions": "-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=70 -XX:MaxHeapFreeRatio=70 -XX:+CMSClassUnloadingEnabled -XX:OnOutOfMemoryError='kill -9 %p' -Dhttp.proxyHost='${proxy_http_host}' -Dhttp.proxyPort='${proxy_http_port}' -Dhttp.nonProxyHosts='${proxy_no_proxy}' -Dhttps.proxyHost='${proxy_https_host}' -Dhttps.proxyPort='${proxy_https_port}'"
-    "spark.driver.extraJavaOptions": "-XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=70 -XX:MaxHeapFreeRatio=70 -XX:+CMSClassUnloadingEnabled -XX:OnOutOfMemoryError='kill -9 %p' -Dhttp.proxyHost='${proxy_http_host}' -Dhttp.proxyPort='${proxy_http_port}' -Dhttp.nonProxyHosts='${proxy_no_proxy}' -Dhttps.proxyHost='${proxy_https_host}' -Dhttps.proxyPort='${proxy_https_port}'"
-    "spark.sql.warehouse.dir": "s3://${s3_published_bucket}/pdm-dataset/hive/external"
-    "spark.dynamicAllocation.enabled": "true"
-    "spark.default.parallelism": "30"
-    "spark.dynamicAllocation.initialExecutors": "10"
-    "spark.dynamicAllocation.minExecutors": "10"
-    "spark.dynamicAllocation.maxExecutors": "20"
 - Classification: "hive-site"
   Properties:
     "hive.metastore.schema.verification": "false"

--- a/steps/clean_dictionary_data.sh
+++ b/steps/clean_dictionary_data.sh
@@ -14,18 +14,18 @@ DICTIONARY_LOCATION="${dictionary_location}"
     }
 
     log_wrapper_message "Uploading initialOrganisation.json "
-    aws s3 cp $DICTIONARY_LOCATION/site/initialOrganisation.json /opt/emr/sql/initialOrganisation.json
+    aws s3 cp $DICTIONARY_LOCATION/unclean/site/initialOrganisation.json /opt/emr/sql/initialOrganisation.json
     tr -d '\n' < /opt/emr/sql/initialOrganisation.json > /opt/emr/sql/initialOrganisation_tmp.json
     aws s3 cp /opt/emr/sql/initialOrganisation_tmp.json $DICTIONARY_LOCATION/site/initialOrganisation.json
 
     log_wrapper_message "Uploading initialOrganisation-NorthernIreland.json "
-    aws s3 cp $DICTIONARY_LOCATION/site/initialOrganisation-NorthernIreland.json /opt/emr/sql/initialOrganisation-NorthernIreland.json
+    aws s3 cp $DICTIONARY_LOCATION/unclean/site/initialOrganisation-NorthernIreland.json /opt/emr/sql/initialOrganisation-NorthernIreland.json
     tr -d '\n' < /opt/emr/sql/initialOrganisation-NorthernIreland.json > /opt/emr/sql/initialOrganisation-NorthernIreland_tmp.json
     aws s3 cp /opt/emr/sql/initialOrganisation-NorthernIreland_tmp.json $DICTIONARY_LOCATION/site/initialOrganisation-NorthernIreland.json
 
 
     log_wrapper_message "Uploading initialDeliveryUnitAddresses_tagged "
-    aws s3 cp $DICTIONARY_LOCATION/data/address/initialDeliveryUnitAddresses.json /opt/emr/sql/initialDeliveryUnitAddresses.json
+    aws s3 cp $DICTIONARY_LOCATION/unclean/data/address/initialDeliveryUnitAddresses.json /opt/emr/sql/initialDeliveryUnitAddresses.json
     tr -d '\n' < /opt/emr/sql/initialDeliveryUnitAddresses.json > /opt/emr/sql/initialDeliveryUnitAddresses_tmp.json
     ex -sc '1i|{"addresses" : ' -cx /opt/emr/sql/initialDeliveryUnitAddresses_tmp.json
     echo "}" >> /opt/emr/sql/initialDeliveryUnitAddresses_tmp.json
@@ -34,7 +34,7 @@ DICTIONARY_LOCATION="${dictionary_location}"
 
 
     log_wrapper_message "Uploading initialDeliveryUnitAddresses_tagged "
-    aws s3 cp $DICTIONARY_LOCATION/data/address/initialDeliveryUnitAddresses.json /opt/emr/sql/initialDeliveryUnitAddresses.json
+    aws s3 cp $DICTIONARY_LOCATION/unclean/data/address/initialDeliveryUnitAddresses.json /opt/emr/sql/initialDeliveryUnitAddresses.json
     tr -d '\n' < /opt/emr/sql/initialDeliveryUnitAddresses.json > /opt/emr/sql/initialDeliveryUnitAddresses_tmp.json
     aws s3 cp /opt/emr/sql/initialDeliveryUnitAddresses.json $DICTIONARY_LOCATION/data/address/initialDeliveryUnitAddresses.json
 


### PR DESCRIPTION
Removed spark from PDM
Set site and address files to be downloaded to unclean folder so that the cleans files can be put into the site and address folder respectively
Set clean_dictionary_data.sh to read from uclean location