### PR TITLE
Avoid the need to be able to read secret values for RDS

### DIFF
--- a/cluster_config.tf
+++ b/cluster_config.tf
@@ -47,9 +47,9 @@ resource "aws_s3_bucket_object" "steps" {
   )
 }
 
-data "aws_secretsmanager_secret_version" "rds_aurora_secrets" {
-  provider  = aws
-  secret_id = "metadata-store-pdm-writer"
+data "aws_secretsmanager_secret" "rds_aurora_secrets" {
+  provider = aws
+  name     = "metadata-store-pdm-writer"
 }
 
 resource "aws_s3_bucket_object" "configurations" {
@@ -67,7 +67,7 @@ resource "aws_s3_bucket_object" "configurations" {
       proxy_https_port             = data.terraform_remote_state.internal_compute.outputs.internet_proxy.port
       emrfs_metadata_tablename     = local.emrfs_metadata_tablename
       hive_metsatore_username      = var.metadata_store_pdm_writer_username
-      hive_metastore_pwd           = data.aws_secretsmanager_secret_version.rds_aurora_secrets.secret_id
+      hive_metastore_pwd           = data.aws_secretsmanager_secret.rds_aurora_secrets.name
       hive_metastore_endpoint      = data.terraform_remote_state.adg.outputs.hive_metastore.rds_cluster.endpoint
       hive_metastore_database_name = data.terraform_remote_state.adg.outputs.hive_metastore.rds_cluster.database_name
     }

--- a/emr-launcher.tf
+++ b/emr-launcher.tf
@@ -168,7 +168,7 @@ data "aws_iam_policy_document" "pdm_emr_launcher_getsecrets" {
     ]
 
     resources = [
-      data.aws_secretsmanager_secret_version.rds_aurora_secrets.arn,
+      data.aws_secretsmanager_secret.rds_aurora_secrets.arn,
     ]
   }
 }


### PR DESCRIPTION
Using the name attribute of the secret resource itself, and not
from the secret_version resource means that we don't need to have
access to the actual secret values. This enables us to locally
plan against non-dev environments.