### PR TITLE
Changed keep_cluster_alive setting from true to false in integration env

### DIFF
--- a/local.tf
+++ b/local.tf
@@ -103,7 +103,7 @@ locals {
   keep_cluster_alive = {
     development = true
     qa          = false
-    integration = true
+    integration = false
     preprod     = false
     production  = false
   }


### PR DESCRIPTION
Hello All,

This change is to set the value of keep_cluster_alive flag from true to false in integration environment, as too many PDM EMR keeps on running which impacts the connectivity issues with mysql database for other EMR engines which results into bootstrap failures.

Thanks and Regards
Ashis Prasad