### PR TITLE
More cores for PDM and config changes for performance

### DIFF
--- a/ci/meta.yml
+++ b/ci/meta.yml
@@ -6,9 +6,8 @@ meta:
         image_resource:
           type: docker-image
           source:
-            repository: ((docker-awscli.repository))
-            version: ((docker-awscli.version))
-            tag: ((docker-awscli.version))
+            repository: ((dataworks.terraform_repository))
+            tag: ((dataworks.terraform_version))
         params:
           TF_INPUT: false
           AWS_REGION: ((dataworks.aws_region))

--- a/ci/meta.yml
+++ b/ci/meta.yml
@@ -3,11 +3,6 @@ meta:
     terraform-common-config:
       config:
         platform: linux
-        image_resource:
-          type: docker-image
-          source:
-            repository: ((dataworks.terraform_repository))
-            tag: ((dataworks.terraform_version))
         params:
           TF_INPUT: false
           AWS_REGION: ((dataworks.aws_region))
@@ -19,6 +14,12 @@ meta:
       task: terraform-bootstrap
       .: (( inject meta.plan.terraform-common-config ))
       config:
+        image_resource:
+          type: docker-image
+          source:
+            repository: ((dataworks.docker_awscli_repository))
+            version: ((dataworks.docker_awscli_version))
+            tag: ((dataworks.docker_awscli_version))
         run:
           path: sh
           args:

--- a/cluster_config.tf
+++ b/cluster_config.tf
@@ -70,10 +70,11 @@ resource "aws_s3_bucket_object" "configurations" {
       proxy_http_port              = data.terraform_remote_state.internal_compute.outputs.internet_proxy.port
       proxy_https_host             = data.terraform_remote_state.internal_compute.outputs.internet_proxy.host
       proxy_https_port             = data.terraform_remote_state.internal_compute.outputs.internet_proxy.port
-      hive_metsatore_username      = var.metadata_store_pdm_writer_username
+      hive_metastore_username      = var.metadata_store_pdm_writer_username
       hive_metastore_pwd           = data.aws_secretsmanager_secret.rds_aurora_secrets.name
       hive_metastore_endpoint      = data.terraform_remote_state.adg.outputs.hive_metastore.rds_cluster.endpoint
       hive_metastore_database_name = data.terraform_remote_state.adg.outputs.hive_metastore.rds_cluster.database_name
+      hive_compaction_threads      = local.hive_compaction_threads[local.environment]
     }
   )
 }

--- a/cluster_config/configurations.yaml.tpl
+++ b/cluster_config/configurations.yaml.tpl
@@ -16,14 +16,16 @@ Configurations:
     "hive.enforce.bucketing": "true"
     "hive.exec.dynamic.partition.mode": "nostrict"
     "hive.compactor.initiator.on": "true"
-    "hive.compactor.worker.threads": "1"
+    "hive.compactor.worker.threads": "${hive_compaction_threads}"
     "hive.support.concurrency": "true"
     "javax.jdo.option.ConnectionURL": "jdbc:mysql://${hive_metastore_endpoint}:3306/${hive_metastore_database_name}?createDatabaseIfNotExist=true"
     "javax.jdo.option.ConnectionDriverName": "org.mariadb.jdbc.Driver"
-    "javax.jdo.option.ConnectionUserName": ${hive_metsatore_username}
+    "javax.jdo.option.ConnectionUserName": ${hive_metastore_username}
     "javax.jdo.option.ConnectionPassword": ${hive_metastore_pwd}
     "hive.mapred.mode": "nonstrict"
     "hive.strict.checks.cartesian.product": "false"
+    "hive.exec.parallel": "true"
+    "hive.vectorized.execution.enabled": "true"
 - Classification: "emrfs-site"
   Properties:
     "fs.s3.maxConnections": "10000"

--- a/local.tf
+++ b/local.tf
@@ -145,4 +145,12 @@ locals {
     preprod     = "TERMINATE_CLUSTER"
     production  = "TERMINATE_CLUSTER"
   }
+
+  hive_compaction_threads = {
+    development = "1"
+    qa          = "1"
+    integration = "1"
+    preprod     = "1"
+    production  = "12" # vCPU in the instance / 8
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -88,7 +88,7 @@ variable "emr_core_instance_count" {
     qa          = "2"
     integration = "2"
     preprod     = "2"
-    production  = "22"
+    production  = "35"
   }
 }
 


### PR DESCRIPTION
More cores for PDM and config changes for performance.

AWS config for the threads ->

```
- hive.compactor.worker.threads – Number of worker threads to run in the instance. The default is 1 or vCores/8, whichever is greater.
```

Justification for the config switches -> qubole.com/blog/hive-best-practices/