### PR TITLE
dropping table before adding new columns

### DIFF
--- a/steps/create-hive-dynamo-table.sh
+++ b/steps/create-hive-dynamo-table.sh
@@ -14,10 +14,10 @@ set -euo pipefail
 
     hive -e "CREATE DATABASE IF NOT EXISTS AUDIT; \
     DROP TABLE IF EXISTS AUDIT.data_pipeline_metadata_hive; \
-    CREATE EXTERNAL TABLE IF NOT EXISTS AUDIT.data_pipeline_metadata_hive (Correlation_Id STRING, Run_Id BIGINT, DataProduct STRING, DateProductRun STRING, Status STRING) \
+    CREATE EXTERNAL TABLE IF NOT EXISTS AUDIT.data_pipeline_metadata_hive (Correlation_Id STRING, Run_Id BIGINT, DataProduct STRING, DateProductRun STRING, Status STRING, CurrentStep STRING) \
     STORED BY 'org.apache.hadoop.hive.dynamodb.DynamoDBStorageHandler' \
     TBLPROPERTIES ('dynamodb.table.name'='${dynamodb_table_name}', \
-    'dynamodb.column.mapping' = 'Correlation_Id:Correlation_Id,Run_Id:Run_Id,DataProduct:DataProduct,DateProductRun:Date,Status:Status','dynamodb.null.serialization' = 'true');"
+    'dynamodb.column.mapping' = 'Correlation_Id:Correlation_Id,Run_Id:Run_Id,DataProduct:DataProduct,DateProductRun:Date,Status:Status,CurrentStep:CurrentStep','dynamodb.null.serialization' = 'true');"
 
     log_wrapper_message "Finished creating external hive table"
 

--- a/steps/create-hive-dynamo-table.sh
+++ b/steps/create-hive-dynamo-table.sh
@@ -13,6 +13,7 @@ set -euo pipefail
     log_wrapper_message "Creating external hive table"
 
     hive -e "CREATE DATABASE IF NOT EXISTS AUDIT; \
+    DROP TABLE IF EXISTS AUDIT.data_pipeline_metadata_hive; \
     CREATE EXTERNAL TABLE IF NOT EXISTS AUDIT.data_pipeline_metadata_hive (Correlation_Id STRING, Run_Id BIGINT, DataProduct STRING, DateProductRun STRING, Status STRING) \
     STORED BY 'org.apache.hadoop.hive.dynamodb.DynamoDBStorageHandler' \
     TBLPROPERTIES ('dynamodb.table.name'='${dynamodb_table_name}', \


### PR DESCRIPTION
Adding a new column to existing metadata table called CurrentStep. This allows us to track the current running step of the EMR cluster which should enable us to have more granular controls going forward. 
 
The table has to be dropped in hive first for it to be able to add new columns. The existing data remains. 