### PR TITLE
Add cloudwatch event trigger on PDM success

### DIFF
--- a/cloudwatch_events.tf
+++ b/cloudwatch_events.tf
@@ -1,3 +1,54 @@
+locals {
+  data_classification = {
+    config_bucket = data.terraform_remote_state.common.outputs.config_bucket
+    config_prefix = data.terraform_remote_state.aws_s3_object_tagger.outputs.pdm_object_tagger_data_classification.config_prefix
+  }
+}
+
+# AWS IAM for Cloudwatch event triggers
+data "aws_iam_policy_document" "cloudwatch_events_assume_role" {
+  statement {
+    sid    = "CloudwatchEventsAssumeRolePolicy"
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      identifiers = ["events.amazonaws.com"]
+      type = "Service"
+    }
+  }
+}
+
+resource "aws_iam_role" "allow_batch_job_submission" {
+  name               = "AllowBatchJobSubmission"
+  assume_role_policy = data.aws_iam_policy_document.cloudwatch_events_assume_role.json
+  tags               = local.common_tags
+}
+
+data "aws_iam_policy_document" "allow_batch_job_submission" {
+  statement {
+    sid    = "AllowBatchJobSubmission"
+    effect = "Allow"
+
+    actions = [
+      "batch:SubmitJob",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "allow_batch_job_submission" {
+  name   = "AllowBatchJobSubmission"
+  policy = data.aws_iam_policy_document.allow_batch_job_submission.json
+}
+
+resource "aws_iam_role_policy_attachment" "allow_batch_job_submission" {
+  role       = aws_iam_role.allow_batch_job_submission.name
+  policy_arn = aws_iam_policy.allow_batch_job_submission.arn
+}
+
 resource "aws_cloudwatch_event_rule" "pdm_terminated_with_errors_rule" {
   name          = "pdm_terminated_with_errors_rule"
   description   = "Sends failed message to slack when pdm cluster terminates with errors"
@@ -70,6 +121,20 @@ resource "aws_cloudwatch_event_rule" "pdm_success" {
   }
 }
 EOF
+}
+
+resource "aws_cloudwatch_event_target" "pdm_success_start_object_tagger" {
+  target_id = "pdm_success"
+  rule = aws_cloudwatch_event_rule.pdm_success.name
+  arn = data.terraform_remote_state.aws_s3_object_tagger.outputs.pdm_object_tagger_batch.job_queue.arn
+  role_arn = aws_iam_role.allow_batch_job_submission.arn
+
+  batch_target {
+    job_definition = data.terraform_remote_state.aws_s3_object_tagger.outputs.pdm_object_tagger_batch.job_definition.id
+    job_name = "pdm_success_cloudwatch_event"
+  }
+
+  input = "{\"command\": [\"--data-s3-prefix=data/uc\", \"--csv-location=s3://${local.data_classification.config_bucket.id}/${local.data_classification.config_prefix}/data_classification.csv\"]}"
 }
 
 

--- a/cloudwatch_events.tf
+++ b/cloudwatch_events.tf
@@ -134,9 +134,8 @@ resource "aws_cloudwatch_event_target" "pdm_success_start_object_tagger" {
     job_name = "pdm_success_cloudwatch_event"
   }
 
-  input = "{\"command\": [\"--data-s3-prefix=data/uc\", \"--csv-location=s3://${local.data_classification.config_bucket.id}/${local.data_classification.config_prefix}/data_classification.csv\"]}"
+  input = "{\"Parameters\": {\"data-s3-prefix\": \"data/uc\", \"csv-location\": \"s3://${local.data_classification.config_bucket.id}/${local.data_classification.config_prefix}/data_classification.csv\"}}"
 }
-
 
 resource "aws_cloudwatch_metric_alarm" "pdm_success" {
   alarm_name                = "pdm_completed_all_steps"

--- a/cloudwatch_events.tf
+++ b/cloudwatch_events.tf
@@ -131,7 +131,7 @@ resource "aws_cloudwatch_event_target" "pdm_success_start_object_tagger" {
 
   batch_target {
     job_definition = data.terraform_remote_state.aws_s3_object_tagger.outputs.pdm_object_tagger_batch.job_definition.id
-    job_name = "pdm_success_cloudwatch_event"
+    job_name = "pdm-success-cloudwatch-event"
   }
 
   input = "{\"Parameters\": {\"data-s3-prefix\": \"data/uc\", \"csv-location\": \"s3://${local.data_classification.config_bucket.id}/${local.data_classification.config_prefix}/data_classification.csv\"}}"

--- a/terraform.tf.j2
+++ b/terraform.tf.j2
@@ -204,3 +204,17 @@ data "terraform_remote_state" "adg" {
     dynamodb_table = "remote_state_locks"
   }
 }
+
+data "terraform_remote_state" "aws_s3_object_tagger" {
+  backend   = "s3"
+  workspace = terraform.workspace
+
+  config = {
+    bucket         = "{{state_file_bucket}}"
+    key            = "terraform/dataworks/dataworks-aws-s3-object-tagger.tfstate"
+    region         = "{{state_file_region}}"
+    encrypt        = true
+    kms_key_id     = "arn:aws:kms:{{state_file_region}}:{{state_file_account}}:key/{{state_file_kms_key}}"
+    dynamodb_table = "remote_state_locks"
+  }
+}


### PR DESCRIPTION
Will trigger batch job for pdm-object-tagging.
Required IAM permissions and references to dataworks-aws-s3-object-tagger output