### PR TITLE
Split load over spots and on-demand

### DIFF
--- a/cloudwatch_events.tf
+++ b/cloudwatch_events.tf
@@ -15,7 +15,7 @@ data "aws_iam_policy_document" "cloudwatch_events_assume_role" {
 
     principals {
       identifiers = ["events.amazonaws.com"]
-      type = "Service"
+      type        = "Service"
     }
   }
 }
@@ -125,13 +125,13 @@ EOF
 
 resource "aws_cloudwatch_event_target" "pdm_success_start_object_tagger" {
   target_id = "pdm_success"
-  rule = aws_cloudwatch_event_rule.pdm_success.name
-  arn = data.terraform_remote_state.aws_s3_object_tagger.outputs.pdm_object_tagger_batch.job_queue.arn
-  role_arn = aws_iam_role.allow_batch_job_submission.arn
+  rule      = aws_cloudwatch_event_rule.pdm_success.name
+  arn       = data.terraform_remote_state.aws_s3_object_tagger.outputs.pdm_object_tagger_batch.job_queue.arn
+  role_arn  = aws_iam_role.allow_batch_job_submission.arn
 
   batch_target {
     job_definition = data.terraform_remote_state.aws_s3_object_tagger.outputs.pdm_object_tagger_batch.job_definition.id
-    job_name = "pdm-success-cloudwatch-event"
+    job_name       = "pdm-success-cloudwatch-event"
   }
 
   input = "{\"Parameters\": {\"data-s3-prefix\": \"data/uc\", \"csv-location\": \"s3://${local.data_classification.config_bucket.id}/${local.data_classification.config_prefix}/data_classification.csv\"}}"

--- a/cluster_config.tf
+++ b/cluster_config.tf
@@ -36,6 +36,7 @@ resource "aws_s3_bucket_object" "instances" {
       instance_type_core_two   = var.emr_instance_type_core_two[local.environment]
       instance_type_core_three = var.emr_instance_type_core_three[local.environment]
       core_instance_count      = var.emr_core_instance_count[local.environment]
+      core_spot_instance_count = var.emr_core_spot_instance_count[local.environment]
     }
   )
 }

--- a/cluster_config/instances.yaml.tpl
+++ b/cluster_config/instances.yaml.tpl
@@ -24,6 +24,7 @@ Instances:
   - InstanceFleetType: "CORE"
     Name: CORE
     TargetOnDemandCapacity: ${core_instance_count}
+    TargetSpotCapacity: ${core_spot_instance_count}
     InstanceTypeConfigs:
     - EbsConfiguration:
         EbsBlockDeviceConfigs:
@@ -46,3 +47,11 @@ Instances:
             VolumeType: "gp2"
           VolumesPerInstance: 1
       InstanceType: "${instance_type_core_three}"
+      BidPriceAsPercentageOfOnDemandPrice: "100"
+    LaunchSpecifications:
+    - OnDemandSpecification: 
+        AllocationStrategy: "lowest-price"
+        - SpotSpecification: 
+            AllocationStrategy: "capacity-optimized"
+            TimeoutDurationMinutes: "120"
+            TimeoutAction: "SWITCH_TO_ON_DEMAND"

--- a/variables.tf
+++ b/variables.tf
@@ -84,10 +84,20 @@ variable "metadata_store_pdm_writer_username" {
 
 variable "emr_core_instance_count" {
   default = {
-    development = "2"
-    qa          = "2"
-    integration = "2"
-    preprod     = "2"
-    production  = "35"
+    development = "1"
+    qa          = "1"
+    integration = "1"
+    preprod     = "1"
+    production  = "20"
+  }
+}
+
+variable "emr_core_spot_instance_count" {
+  default = {
+    development = "1"
+    qa          = "1"
+    integration = "1"
+    preprod     = "1"
+    production  = "15"
   }
 }


### PR DESCRIPTION
This splits the `CORE` node requests over spot instances and on-demand instances.  If spot instances fail, it will attempt on-demand.