### PR TITLE
Additional metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ This clusters metrics are exported using Json Exporter. The metrics file is crea
 This file is then uploaded to S3, where the Json Exporter scrapes the metrics and stores them in Prometheus. 
 The S3 file is deleted at the start and end of every run to prevent stale metrics being scraped. 
 
+Additional metrics such as pdm_views_table_count, pdm_views_row_count and pdm_views_max_date are sent to the PDM pushgateway.
+These metrics represent the number of tables in the PDM database, the total number of row in the PDM database and the time at which the latest raw entry was added.
+
 # Upgrading to EMR 6.2.0
 
 There is a requirement for our data products to start using Hive 3 instead of Hive 2. Hive 3 comes bundled with EMR 6.2.0 

--- a/bootstrap_actions/cloudwatch.sh
+++ b/bootstrap_actions/cloudwatch.sh
@@ -207,6 +207,12 @@ cat > /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json <<CWAGEN
             "timezone": "UTC"
           },
           {
+            "file_path": "/var/log/pdm/additional-metrics.log",
+            "log_group_name": "$${cwa_steps_loggrp_name}",
+            "log_stream_name": "{instance_id}-additional-metrics.log",
+            "timezone": "UTC"
+          },
+          {
             "file_path": "/var/log/pdm/e2e.log",
             "log_group_name": "$${cwa_tests_loggrp_name}",
             "log_stream_name": "{instance_id}-e2e.log",

--- a/bootstrap_actions/status_metrics.sh
+++ b/bootstrap_actions/status_metrics.sh
@@ -48,9 +48,6 @@
 
   push_metric() {
     log_wrapper_message "Sending to push gateway with value $1"
-    log_wrapper_message "Export Date $EXPORT_DATE"
-    log_wrapper_message "Cluster Id $CLUSTER_ID"
-    log_wrapper_message "Correlation Id $CORRELATION_ID"
 
     cat << EOF | curl --data-binary @- "http://${pdm_pushgateway_hostname}:9091/metrics/job/pdm"
                 pdm_status{component="PDM",snapshot_type="$SNAPSHOT_TYPE", export_date="$EXPORT_DATE", cluster_id="$CLUSTER_ID",correlation_id="$CORRELATION_ID"} $1

--- a/cluster_config/steps.yaml.tpl
+++ b/cluster_config/steps.yaml.tpl
@@ -102,7 +102,7 @@ Steps:
     Args:
     - "/var/ci/additional-metrics.sh"
     Jar: "s3://eu-west-2.elasticmapreduce/libs/script-runner/script-runner.jar"
-  ActionOnFailure: "${action_on_failure}"
+  ActionOnFailure: "CONTINUE"
 - Name: "flush-gateway"
   HadoopJarStep:
     Args:

--- a/cluster_config/steps.yaml.tpl
+++ b/cluster_config/steps.yaml.tpl
@@ -97,6 +97,12 @@ Steps:
     - "/var/ci/collect-metrics.sh"
     Jar: "s3://eu-west-2.elasticmapreduce/libs/script-runner/script-runner.jar"
   ActionOnFailure: "${action_on_failure}"
+- Name: "additional-metrics"
+  HadoopJarStep:
+    Args:
+    - "/var/ci/additional-metrics.sh"
+    Jar: "s3://eu-west-2.elasticmapreduce/libs/script-runner/script-runner.jar"
+  ActionOnFailure: "${action_on_failure}"
 - Name: "flush-gateway"
   HadoopJarStep:
     Args:

--- a/local.tf
+++ b/local.tf
@@ -16,6 +16,7 @@ locals {
   data_pipeline_metadata          = data.terraform_remote_state.internal_compute.outputs.data_pipeline_metadata_dynamo.name
   hive_metastore_location         = "data/uc"
   hive_data_location              = "data"
+  metastore_reader_secret_name    = "metadata-store-v2-adg-reader"
   common_tags = {
     Environment  = local.environment
     Application  = local.emr_cluster_name

--- a/secrets.tf
+++ b/secrets.tf
@@ -5,10 +5,6 @@ data "aws_secretsmanager_secret" "pdm_secret" {
 data "aws_secretsmanager_secret" "metastore_reader_secret" {
   name = local.metastore_reader_secret_name
 }
-// TODO: determine wether to get the secret using CLI, or pass into script using jsonencode(data.aws_secretsmanager_secret_version.metastore_secret.secret_string)["password"]
-//data "aws_secretsmanager_secret_version" "metastore_secret"{
-//  secret_id = data.aws_secretsmanager_secret.metastore_secret.id
-//}
 
 data "aws_iam_policy_document" "pdm_dataset_secretsmanager" {
   statement {
@@ -20,7 +16,7 @@ data "aws_iam_policy_document" "pdm_dataset_secretsmanager" {
 
     resources = [
       data.aws_secretsmanager_secret.pdm_secret.arn,
-      data.aws_secretsmanager_secret.metastore_secret.arn
+      data.aws_secretsmanager_secret.metastore_reader_secret.arn
     ]
   }
 }

--- a/secrets.tf
+++ b/secrets.tf
@@ -2,6 +2,14 @@ data "aws_secretsmanager_secret" "pdm_secret" {
   name = local.secret_name
 }
 
+data "aws_secretsmanager_secret" "metastore_reader_secret" {
+  name = local.metastore_reader_secret_name
+}
+// TODO: determine wether to get the secret using CLI, or pass into script using jsonencode(data.aws_secretsmanager_secret_version.metastore_secret.secret_string)["password"]
+//data "aws_secretsmanager_secret_version" "metastore_secret"{
+//  secret_id = data.aws_secretsmanager_secret.metastore_secret.id
+//}
+
 data "aws_iam_policy_document" "pdm_dataset_secretsmanager" {
   statement {
     effect = "Allow"
@@ -11,7 +19,8 @@ data "aws_iam_policy_document" "pdm_dataset_secretsmanager" {
     ]
 
     resources = [
-      data.aws_secretsmanager_secret.pdm_secret.arn
+      data.aws_secretsmanager_secret.pdm_secret.arn,
+      data.aws_secretsmanager_secret.metastore_secret.arn
     ]
   }
 }

--- a/steps.tf
+++ b/steps.tf
@@ -184,7 +184,6 @@ resource "aws_s3_bucket_object" "additional_metrics" {
       uc_db                   = local.uc_db
       data_location           = local.data_location
       hive_metastore_location = local.hive_metastore_location
-      data_location           = local.data_location
       metastore_secret_id     = data.aws_secretsmanager_secret.metastore_reader_secret.id
     }
   )

--- a/steps.tf
+++ b/steps.tf
@@ -175,3 +175,16 @@ resource "aws_s3_bucket_object" "flush_s3" {
     }
   )
 }
+
+resource "aws_s3_bucket_object" "additional_metrics" {
+  bucket = data.terraform_remote_state.common.outputs.config_bucket.id
+  key    = "component/pdm-dataset-generation/additional_metrics.sh"
+  content = templatefile("${path.module}/steps/additional_metrics.sh",
+    {
+      uc_db                   = local.uc_db
+      data_location           = local.data_location
+      hive_metastore_location = local.hive_metastore_location
+      data_location           = local.data_location
+    }
+  )
+}

--- a/steps.tf
+++ b/steps.tf
@@ -182,8 +182,6 @@ resource "aws_s3_bucket_object" "additional_metrics" {
   content = templatefile("${path.module}/steps/additional_metrics.sh",
     {
       uc_db                     = local.uc_db
-      data_location             = local.data_location
-      hive_metastore_location   = local.hive_metastore_location
       metastore_secret_id       = data.aws_secretsmanager_secret.metastore_reader_secret.id
       pdm_pushgateway_hostname  = data.terraform_remote_state.metrics_infrastructure.outputs.pdm_pushgateway_hostname
     }

--- a/steps.tf
+++ b/steps.tf
@@ -185,9 +185,6 @@ resource "aws_s3_bucket_object" "additional_metrics" {
       data_location           = local.data_location
       hive_metastore_location = local.hive_metastore_location
       data_location           = local.data_location
-      hive_metastore_endpoint = data.terraform_remote_state.internal_compute.outputs.hive_metastore_v2.rds_cluster.endpoint
-      hive_metastore_username = jsondecode(data.aws_secretsmanager_secret_version.metastore_secret.secret_string)["username"]
-      hive_metastore_db       = data.terraform_remote_state.internal_compute.outputs.hive_metastore_v2.rds_cluster.database_name
       metastore_secret_id     = data.aws_secretsmanager_secret.metastore_reader_secret.id
     }
   )

--- a/steps.tf
+++ b/steps.tf
@@ -185,6 +185,10 @@ resource "aws_s3_bucket_object" "additional_metrics" {
       data_location           = local.data_location
       hive_metastore_location = local.hive_metastore_location
       data_location           = local.data_location
+      hive_metastore_endpoint = data.terraform_remote_state.internal_compute.outputs.hive_metastore_v2.rds_cluster.endpoint
+      hive_metastore_username = jsondecode(data.aws_secretsmanager_secret_version.metastore_secret.secret_string)["username"]
+      hive_metastore_db       = data.terraform_remote_state.internal_compute.outputs.hive_metastore_v2.rds_cluster.database_name
+      metastore_secret_id     = data.aws_secretsmanager_secret.metastore_reader_secret.id
     }
   )
 }

--- a/steps.tf
+++ b/steps.tf
@@ -181,10 +181,11 @@ resource "aws_s3_bucket_object" "additional_metrics" {
   key    = "component/pdm-dataset-generation/additional_metrics.sh"
   content = templatefile("${path.module}/steps/additional_metrics.sh",
     {
-      uc_db                   = local.uc_db
-      data_location           = local.data_location
-      hive_metastore_location = local.hive_metastore_location
-      metastore_secret_id     = data.aws_secretsmanager_secret.metastore_reader_secret.id
+      uc_db                     = local.uc_db
+      data_location             = local.data_location
+      hive_metastore_location   = local.hive_metastore_location
+      metastore_secret_id       = data.aws_secretsmanager_secret.metastore_reader_secret.id
+      pdm_pushgateway_hostname  = data.terraform_remote_state.metrics_infrastructure.outputs.pdm_pushgateway_hostname
     }
   )
 }

--- a/steps/additional_metrics.sh
+++ b/steps/additional_metrics.sh
@@ -12,11 +12,37 @@ set -euo pipefail
     log_pdm_message "$1" "additional-metrics.sh" "$$" "Running as: $USER"
     }
 
+    # get the data needed for metrics labels
+    CORRELATION_ID_FILE=/opt/emr/correlation_id.txt
+    SNAPSHOT_TYPE_FILE=/opt/emr/snapshot_type.txt
+    EXPORT_DATE_FILE=/opt/emr/export_date.txt
+
+    CORRELATION_ID=$(cat $CORRELATION_ID_FILE)
+    SNAPSHOT_TYPE=$(cat $SNAPSHOT_TYPE_FILE)
+    EXPORT_DATE=$(cat $EXPORT_DATE_FILE)
+
+      push_metric() {
+          metric_name=$1
+          metric_value=$2
+
+    cat << EOF | curl --data-binary @- "http://${pdm_pushgateway_hostname}:9091/metrics/job/pdm"
+                $metric_name{component="PDM",snapshot_type="$SNAPSHOT_TYPE", export_date="$EXPORT_DATE", cluster_id="$CLUSTER_ID",correlation_id="$CORRELATION_ID"} metric_value
+EOF
+
+  }
     # count number of tables in views db
     TABLE_NAMES=$(hive -S -e "USE $uc_views_tables; SHOW TABLES;") >> tbls.txt
     WORD_COUNT=($(wc -w tbls.txt))
     TABLE_COUNT=${WORD_COUNT[0]}
+    push_metric "pdm_views_table_count" $TABLE_COUNT
+
 
     # count number of rows in all views dbs
+    
+
+    # query for max date 
+    MAX_DATES=$(hive -S -f ./query_max_dates.hql) #this file will be uploaded to s3
+
+ 
 
 ) >> /var/log/pdm/additional-metrics.log 2>&1

--- a/steps/additional_metrics.sh
+++ b/steps/additional_metrics.sh
@@ -42,7 +42,7 @@ EOF
 
 
     # count number of rows in all views dbs
-    
+
     res=$(aws s3 ls "$S3_LOCATION/$HIVE_METASTORE_LOCATION/$VIEWS_TABLES_DB".db/)
 
     query_string1=""
@@ -73,9 +73,9 @@ EOF
     gauge_name="rowcount_""$UC_DB"
     jq --argjson val "$rows_in_db" '.gauges += {"'"$gauge_name"'":{"value":$val}}' $METRICS_FILE_PATH > "tmp_dir" && sudo mv -f "tmp_dir" $METRICS_FILE_PATH
 
+    res=$(echo $(mysql -u hive -h  -p$pasw -e"use hive_metastore_v2; select sum(param.PARAM_VALUE) FROM TABLE_PARAMS param JOIN TBLS tbl on tbl.TBL_ID = param.TBL_ID JOIN DBS db ON db.DB_ID = tbl.DB_ID WHERE db.NAME = 'uc' and param.PARAM_KEY = 'numRows';") | awk '{print $2}')
+
     # query for max date 
     MAX_DATES=$(hive -S -f ./query_max_dates.hql) #this file will be uploaded to s3
-
- 
 
 ) >> /var/log/pdm/additional-metrics.log 2>&1

--- a/steps/additional_metrics.sh
+++ b/steps/additional_metrics.sh
@@ -2,9 +2,6 @@
 
 set -euo pipefail
 
-#  hive_metastore_password=$(aws secretsmanager get-secret-value --secret-id ${metastore_secret_id} --output text --query SecretString | jq -r '.password')
-#  mysql_port=3306
-
 (
     # Import the logging functions
     source /opt/emr/logging.sh
@@ -42,18 +39,18 @@ EOF
     }
 
     execute_metastore_query(){
-        mysql --defaults-file=<(setup_virtual_conf) -e"${1}"
+        mysql --defaults-file=<(setup_virtual_conf) -e"$${1}"
     }
 
     # count number of tables in views db
     TABLE_COUNT=$(echo $(hive -S -e "USE $UC_DB; SHOW TABLES;") | wc -w )
-    push_metric "pdm_views_table_count" "${TABLE_COUNT}"
+    push_metric "pdm_views_table_count" "$${TABLE_COUNT}"
 
 
     # count number of rows in all views dbs
     ROW_COUNT=$(echo $(execute_metastore_query "select sum(param.PARAM_VALUE) FROM TABLE_PARAMS param JOIN TBLS tbl on tbl.TBL_ID = param.TBL_ID JOIN DBS db ON db.DB_ID = tbl.DB_ID WHERE db.NAME = 'uc' and param.PARAM_KEY = 'numRows';") | awk '{print $2}')
 
-    push_metric "pdm_views_row_count" "${ROW_COUNT}"
+    push_metric "pdm_views_row_count" "$${ROW_COUNT}"
 
     # query for max date
     tbls_data=$(execute_metastore_query "SELECT t.TBL_NAME, c.COLUMN_NAME FROM TBLS t
@@ -70,19 +67,19 @@ EOF
     declare -a tbls_array
 
     tbls_array=(echo $tbls_data)
-    res_column_name="${tbls_array[4]}"
+    res_column_name="$${tbls_array[4]}"
 
     query_str=""
-    for ((i=3; i<${#tbls_array[@]}; i=((i+2)))); do
-        table_name="${tbls_array[i]}"
-        column_name="${tbls_array[((i+1))]}"
-        query_str="$query_str SELECT ${array[((i+1))]} FROM uc.${array[i]} UNION ";
+    for ((i=3; i<$${#tbls_array[@]}; i=((i+2)))); do
+        table_name="$${tbls_array[i]}"
+        column_name="$${tbls_array[((i+1))]}"
+        query_str="$query_str SELECT $${array[((i+1))]} FROM uc.$${array[i]} UNION ";
     done
 
-    query_str="${query_str::-7} ORDER By $res_column_name DESC LIMIT 1"
+    query_str="$${query_str::-7} ORDER By $res_column_name DESC LIMIT 1"
 
     MAX_DATES=$(hive -S -e "$query_str")
 
-    push_metric "pdm_views_max_date" "${MAX_DATE}"
+    push_metric "pdm_views_max_date" "$${MAX_DATE}"
 
 ) >> /var/log/pdm/additional-metrics.log 2>&1

--- a/steps/additional_metrics.sh
+++ b/steps/additional_metrics.sh
@@ -14,6 +14,7 @@ set -euo pipefail
     UC_DB="${uc_db}"
     S3_LOCATION="${data_location}"
     HIVE_METASTORE_LOCATION="${hive_metastore_location}"
+    METRICS_FILE_PATH=/var/log/hive/metrics.json
 
     # get the data needed for metrics labels
     CORRELATION_ID_FILE=/opt/emr/correlation_id.txt

--- a/steps/additional_metrics.sh
+++ b/steps/additional_metrics.sh
@@ -11,6 +11,9 @@ set -euo pipefail
     function log_wrapper_message() {
     log_pdm_message "$1" "additional-metrics.sh" "$$" "Running as: $USER"
     }
+    UC_DB="${uc_db}"
+    S3_LOCATION="${data_location}"
+    HIVE_METASTORE_LOCATION="${hive_metastore_location}"
 
     # get the data needed for metrics labels
     CORRELATION_ID_FILE=/opt/emr/correlation_id.txt
@@ -31,7 +34,7 @@ EOF
 
   }
     # count number of tables in views db
-    TABLE_NAMES=$(hive -S -e "USE $uc_views_tables; SHOW TABLES;") >> tbls.txt
+    TABLE_NAMES=$(hive -S -e "USE $UC_DB; SHOW TABLES;") >> tbls.txt
     WORD_COUNT=($(wc -w tbls.txt))
     TABLE_COUNT=${WORD_COUNT[0]}
     push_metric "pdm_views_table_count" $TABLE_COUNT
@@ -39,6 +42,35 @@ EOF
 
     # count number of rows in all views dbs
     
+    res=$(aws s3 ls "$S3_LOCATION/$HIVE_METASTORE_LOCATION/$VIEWS_TABLES_DB".db/)
+
+    query_string1=""
+    query_string2=""
+    new_line=$'\n'
+    tb_names=$(hive -S -e "USE $UC_DB; SHOW TABLES;")
+    for tb_name in "${tb_names[@]}"
+      do
+        if [[ "$tables_string" == *"$tb_name/"* ]]
+        then
+        query_string1="$query_string1" "ANALYZE TABLE ""$UC_DB"".""$tb_name"" COMPUTE STATISTICS;$new_line"
+        query_string2="$query_string2" "SELECT '""$UC_DB"".""$tb_name""'; SHOW TBLPROPERTIES ""$UC_DB"".""$tb_name""('numRows');$new_line"
+        fi
+      done
+    echo "$query_string1" | tee query_cs.hql
+    echo "$query_string2" | tee query_sp.hql
+    hive -S -f ./query_cs.hql
+    outp=$(hive -S -f ./query_sp.hql)
+    query_string1=""
+    query_string2=""
+    rows_in_db=$((0))
+    separated=$(echo "${outp}" | sed -e 's/ /\n/g')
+    rows_in_tables=$(echo "${separated}" | sed -e '/^[0-9]*$/!d')
+    for j in "${rows_in_tables[@]}"
+      do
+        rows_in_db=$((rows_in_db+j))
+      done
+    gauge_name="rowcount_""$UC_DB"
+    jq --argjson val "$rows_in_db" '.gauges += {"'"$gauge_name"'":{"value":$val}}' $METRICS_FILE_PATH > "tmp_dir" && sudo mv -f "tmp_dir" $METRICS_FILE_PATH
 
     # query for max date 
     MAX_DATES=$(hive -S -f ./query_max_dates.hql) #this file will be uploaded to s3

--- a/steps/additional_metrics.sh
+++ b/steps/additional_metrics.sh
@@ -72,16 +72,16 @@ EOF
 
     # Create a query to union all ts columns into one column, sort in descending order and get first (max date)
     query_str=""
-    for ((i=3; i<$${#tbls_array[@]}; i=((i+2)))); do
-        table_name="$${tbls_array[i]}"
-        column_name="$${tbls_array[((i+1))]}"
-        query_str="$query_str SELECT $${tbls_array[((i+1))]} FROM uc.$${tbls_array[i]} UNION ";
+    for (( i=3; i<${#tbls_array[@]}; i=((i+2)) )); do
+        table_name="$${tbls_array[$i]}"
+        column_name="$${tbls_array[(($i+1))]}"
+        query_str="$query_str SELECT $column_name FROM uc.$table_name UNION ";
     done
 
     query_str="$${query_str::-7} ORDER By $res_column_name DESC LIMIT 1"
 
     # Run query in Hive
-    MAX_DATES=$(hive -S -e "$query_str")
+    MAX_DATE=$(hive -S -e "$query_str")
 
     push_metric "pdm_views_max_date" "$${MAX_DATE}"
 

--- a/steps/additional_metrics.sh
+++ b/steps/additional_metrics.sh
@@ -35,7 +35,7 @@ EOF
   }
 
     setup_virtual_conf(){
-      aws --profile dataworks-development secretsmanager get-secret-value --secret-id metadata-store-v2-adg-reader --output text --query SecretString | jq -r '"[client]\npassword=" + .password + "\nuser=" + .username + "\nhost=" + .host + "\nport=" + (.port|tostring) + "\ndatabase=" + .dbInstanceIdentifier'
+      aws secretsmanager get-secret-value --secret-id metadata-store-v2-adg-reader --output text --query SecretString | jq -r '"[client]\npassword=" + .password + "\nuser=" + .username + "\nhost=" + .host + "\nport=" + (.port|tostring) + "\ndatabase=" + .dbInstanceIdentifier'
     }
 
     execute_metastore_query(){

--- a/steps/additional_metrics.sh
+++ b/steps/additional_metrics.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -euo pipefail
+
+(
+    # Import the logging functions
+    source /opt/emr/logging.sh
+    # Import and execute resume step function
+    source /opt/emr/resume_step.sh
+
+    function log_wrapper_message() {
+    log_pdm_message "$1" "additional-metrics.sh" "$$" "Running as: $USER"
+    }
+
+    # count number of tables in views db
+    TABLE_NAMES=$(hive -S -e "USE $uc_views_tables; SHOW TABLES;") >> tbls.txt
+    WORD_COUNT=($(wc -w tbls.txt))
+    TABLE_COUNT=${WORD_COUNT[0]}
+
+    # count number of rows in all views dbs
+
+) >> /var/log/pdm/additional-metrics.log 2>&1

--- a/steps/additional_metrics.sh
+++ b/steps/additional_metrics.sh
@@ -67,15 +67,21 @@ EOF
     declare -a tbls_array
 
     #shellcheck disable=SC2206
-    tbls_array=(echo $tbls_data)
-    res_column_name="$${tbls_array[4]}"
+    full_array=(echo $tbls_data)
+    #shellcheck disable=SC2206,SC2034
+    tbls_array=("$${full_array[@]:3}")
+    res_column_name="$${tbls_array[1]}"
 
     # Create a query to union all ts columns into one column, sort in descending order and get first (max date)
     query_str=""
-    for (( i=3; i<$${#tbls_array[@]}; i=((i+2)) )); do
+
+    #shellcheck disable=SC2066
+    for i in "$${!tbls_array[@]}"; do
+      if [[ $((i % 2)) -eq 0 ]]; then
         table_name="$${tbls_array[$i]}"
-        column_name="$${tbls_array[(($i+1))]}"
+        column_name="$${tbls_array[$((i+1))]}"
         query_str="$query_str SELECT $column_name FROM uc.$table_name UNION "
+      fi
     done
 
     query_str="$${query_str::-7} ORDER By $res_column_name DESC LIMIT 1"


### PR DESCRIPTION
- CW Log group
- Step added for metrics before flush, CONTINUE on failure for all envs.
- Secret id passed in 
- IAM permissions to read secret
- Upload to S3
NB.: I think the script will be installed onto EMR [here](https://github.com/dwp/aws-pdm-dataset-generation/blob/master/bootstrap_actions/download_scripts.sh#L36-L37) from [this path](https://github.com/dwp/aws-pdm-dataset-generation/blob/master/bootstrap_actions.tf#L149-L152) but it seems to be uploaded to [a different bucket path here](https://github.com/dwp/aws-pdm-dataset-generation/compare/additional_metrics?expand=1#diff-8d095f5a12d22f17b8af684ad4616ef1f49c8fe4d44f81edcd7e0ed9d4de1c24R181), so could whoever reviews this confirm that this is indeed the case?