### PR TITLE
success metric expanded to include correct filter for failure of non-mandatory steps

### DIFF
--- a/cloudwatch_events.tf
+++ b/cloudwatch_events.tf
@@ -109,39 +109,10 @@ resource "aws_cloudwatch_event_rule" "pdm_success" {
     "name": [
       "pdm-dataset-generator"
     ],
-    "stateChangeReason": {
-        "code": [
-            "ALL_STEPS_COMPLETED"
-        ]
-    }
-  }
-}
-EOF
-}
-
-resource "aws_cloudwatch_event_rule" "pdm_success_with_errors" {
-  name          = "pdm_success_with_errors"
-  description   = "checks that mandatory steps are complete"
-  event_pattern = <<EOF
-{
-  "source": [
-    "aws.emr"
-  ],
-  "detail-type": [
-    "EMR Cluster State Change"
-  ],
-  "detail": {
-    "state": [
-      "TERMINATED"
-    ],
-    "name": [
-      "pdm-dataset-generator"
-    ],
-    "stateChangeReason": {
-        "message": [
-            "Steps completed with errors"
-        ]
-    }
+    "stateChangeReason": [
+      "{\"code\":\"ALL_STEPS_COMPLETED\",\"message\":\"Steps completed\"}",
+      "{\"code\":\"STEP_FAILURE\",\"message\":\"Steps completed with errors\"}"
+    ]
   }
 }
 EOF
@@ -256,46 +227,6 @@ resource "aws_cloudwatch_metric_alarm" "pdm_success" {
     local.common_tags,
     {
       Name              = "pdm_success",
-      notification_type = "Information",
-      severity          = "Critical"
-    },
-  )
-}
-
-resource "aws_cloudwatch_event_target" "pdm_success_with_errors_start_object_tagger" {
-  target_id = "pdm_success_with_errors"
-  rule      = aws_cloudwatch_event_rule.pdm_success_with_errors.name
-  arn       = data.terraform_remote_state.aws_s3_object_tagger.outputs.s3_object_tagger_batch.pdm_job_queue.arn
-  role_arn  = aws_iam_role.allow_batch_job_submission.arn
-
-  batch_target {
-    job_definition = data.terraform_remote_state.aws_s3_object_tagger.outputs.s3_object_tagger_batch.job_definition.id
-    job_name       = "pdm-success-with-errors-cloudwatch-event"
-  }
-
-  input = "{\"Parameters\": {\"data-s3-prefix\": \"${local.data_classification.data_s3_prefix}\", \"csv-location\": \"s3://${local.data_classification.config_bucket.id}/${local.data_classification.config_prefix}/data_classification.csv\"}}"
-}
-
-resource "aws_cloudwatch_metric_alarm" "pdm_success_with_errors" {
-  count                     = local.pdm_alerts[local.environment] == true ? 1 : 0
-  alarm_name                = "pdm_success_with_errors"
-  comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "1"
-  metric_name               = "TriggeredRules"
-  namespace                 = "AWS/Events"
-  period                    = "60"
-  statistic                 = "Sum"
-  threshold                 = "1"
-  alarm_description         = "Monitoring pdm completion"
-  insufficient_data_actions = []
-  alarm_actions             = [data.terraform_remote_state.security-tools.outputs.sns_topic_london_monitoring.arn]
-  dimensions = {
-    RuleName = aws_cloudwatch_event_rule.pdm_success_with_errors.name
-  }
-  tags = merge(
-    local.common_tags,
-    {
-      Name              = "pdm_success_with_errors",
       notification_type = "Information",
       severity          = "Critical"
     },

--- a/cloudwatch_events.tf
+++ b/cloudwatch_events.tf
@@ -110,7 +110,7 @@ resource "aws_cloudwatch_event_rule" "pdm_success" {
       "pdm-dataset-generator"
     ],
     "stateChangeReason": [
-      "{\"code\":\"ALL_STEPS_COMPLETED\",\"message\":\"Steps completed\"}",
+      "{\"code\":\"ALL_STEPS_COMPLETED\",\"message\":\"Steps completed\"}"
     ]
   }
 }

--- a/cloudwatch_events.tf
+++ b/cloudwatch_events.tf
@@ -118,8 +118,8 @@ EOF
 }
 
 resource "aws_cloudwatch_event_rule" "pdm_success_with_errors" {
-  name          = "pdm_success"
-  description   = "checks that all mandatory steps complete but with failures on non mandatory"
+  name          = "pdm_success_with_errors"
+  description   = "checks that all mandatory steps complete but with failures on non mandatory steps"
   event_pattern = <<EOF
 {
   "source": [

--- a/cloudwatch_events.tf
+++ b/cloudwatch_events.tf
@@ -111,6 +111,31 @@ resource "aws_cloudwatch_event_rule" "pdm_success" {
     ],
     "stateChangeReason": [
       "{\"code\":\"ALL_STEPS_COMPLETED\",\"message\":\"Steps completed\"}",
+    ]
+  }
+}
+EOF
+}
+
+resource "aws_cloudwatch_event_rule" "pdm_success_with_errors" {
+  name          = "pdm_success"
+  description   = "checks that all mandatory steps complete but with failures on non mandatory"
+  event_pattern = <<EOF
+{
+  "source": [
+    "aws.emr"
+  ],
+  "detail-type": [
+    "EMR Cluster State Change"
+  ],
+  "detail": {
+    "state": [
+      "TERMINATED"
+    ],
+    "name": [
+      "pdm-dataset-generator"
+    ],
+    "stateChangeReason": [
       "{\"code\":\"STEP_FAILURE\",\"message\":\"Steps completed with errors\"}"
     ]
   }
@@ -228,6 +253,46 @@ resource "aws_cloudwatch_metric_alarm" "pdm_success" {
     {
       Name              = "pdm_success",
       notification_type = "Information",
+      severity          = "Critical"
+    },
+  )
+}
+
+resource "aws_cloudwatch_event_target" "pdm_success_with_errors_start_object_tagger" {
+  target_id = "pdm_success_with_errors"
+  rule      = aws_cloudwatch_event_rule.pdm_success_with_errors.name
+  arn       = data.terraform_remote_state.aws_s3_object_tagger.outputs.s3_object_tagger_batch.pdm_job_queue.arn
+  role_arn  = aws_iam_role.allow_batch_job_submission.arn
+
+  batch_target {
+    job_definition = data.terraform_remote_state.aws_s3_object_tagger.outputs.s3_object_tagger_batch.job_definition.id
+    job_name       = "pdm-success-with-errors-cloudwatch-event"
+  }
+
+  input = "{\"Parameters\": {\"data-s3-prefix\": \"${local.data_classification.data_s3_prefix}\", \"csv-location\": \"s3://${local.data_classification.config_bucket.id}/${local.data_classification.config_prefix}/data_classification.csv\"}}"
+}
+
+resource "aws_cloudwatch_metric_alarm" "pdm_success_with_errors" {
+  count                     = local.pdm_alerts[local.environment] == true ? 1 : 0
+  alarm_name                = "pdm_success_with_errors"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = "TriggeredRules"
+  namespace                 = "AWS/Events"
+  period                    = "60"
+  statistic                 = "Sum"
+  threshold                 = "1"
+  alarm_description         = "Monitoring pdm completion"
+  insufficient_data_actions = []
+  alarm_actions             = [data.terraform_remote_state.security-tools.outputs.sns_topic_london_monitoring.arn]
+  dimensions = {
+    RuleName = aws_cloudwatch_event_rule.pdm_success_with_errors.name
+  }
+  tags = merge(
+    local.common_tags,
+    {
+      Name              = "pdm_success_with_errors",
+      notification_type = "Warning",
       severity          = "Critical"
     },
   )


### PR DESCRIPTION
- Removing non-working success with errors event and alarm
- Adding in correct `Code` and `Message` filter for actual event 